### PR TITLE
Change base container

### DIFF
--- a/Hackathon/Hackathon.Api/Dockerfile
+++ b/Hackathon/Hackathon.Api/Dockerfile
@@ -1,4 +1,4 @@
-﻿FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine AS base
+﻿FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443


### PR DESCRIPTION
 Change base container because alpine doesn't have the native dependencies required to run onnx