### PR TITLE
Make CORS policy more strict

### DIFF
--- a/Hackathon/Hackathon.Api/Program.cs
+++ b/Hackathon/Hackathon.Api/Program.cs
@@ -1,4 +1,10 @@
+using System.Text.RegularExpressions;
 using Hackathon.Api.Predictors;
+
+var domainRegex =
+    new Regex(
+        @"^(http://localhost:\d{4,5}|https://lemon-wave-0a1dfce03(\.|-)(\d{1,}\.)?(westeurope(\.\d{1,})\.)?azurestaticapps\.net)/?",
+        RegexOptions.Compiled);
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -7,9 +13,9 @@ builder.Services.AddCors(options =>
     options.AddDefaultPolicy(policy =>
     {
         policy
-            .AllowAnyOrigin()
             .AllowAnyMethod()
-            .AllowAnyHeader();
+            .AllowAnyHeader()
+            .SetIsOriginAllowed(domain => domainRegex.IsMatch(domain));
     });
 });
 


### PR DESCRIPTION
This should still allow all of our sources to call it from the browser, but disallow any others.